### PR TITLE
修复服务端加载客户端类导致的崩溃

### DIFF
--- a/common/src/main/kotlin/cn/coostack/cooparticlesapi/annotations/events/EventListener.kt
+++ b/common/src/main/kotlin/cn/coostack/cooparticlesapi/annotations/events/EventListener.kt
@@ -1,8 +1,12 @@
 package cn.coostack.cooparticlesapi.annotations.events
 
 import cn.coostack.cooparticlesapi.CooParticlesConstants
+import cn.coostack.cooparticlesapi.enums.DistType
 
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
-annotation class EventListener(val modId: String = CooParticlesConstants.MOD_ID)
+annotation class EventListener(
+    val modId: String = CooParticlesConstants.MOD_ID,
+    val dist: DistType = DistType.BOTH,
+)

--- a/common/src/main/kotlin/cn/coostack/cooparticlesapi/display/CooParticlesRenderTypes.kt
+++ b/common/src/main/kotlin/cn/coostack/cooparticlesapi/display/CooParticlesRenderTypes.kt
@@ -1,12 +1,12 @@
 package cn.coostack.cooparticlesapi.display
 
-import cn.coostack.cooparticlesapi.platform.CooParticlesServices
+import cn.coostack.cooparticlesapi.platform.CooClientServices
 import net.minecraft.client.renderer.RenderType
 import net.minecraft.resources.ResourceLocation
 
 object CooParticlesRenderTypes {
     private val provider: CooRenderTypesProvider
-        get() = CooParticlesServices.PLATFORM.getRenderTypesProvider()
+        get() = CooClientServices.RENDER_TYPES_PROVIDER
 
     @JvmStatic
     fun glow(): RenderType {

--- a/common/src/main/kotlin/cn/coostack/cooparticlesapi/enums/DistType.kt
+++ b/common/src/main/kotlin/cn/coostack/cooparticlesapi/enums/DistType.kt
@@ -2,6 +2,11 @@ package cn.coostack.cooparticlesapi.enums
 
 enum class DistType {
     /**
+     * Listener is valid on both client and dedicated server.
+     */
+    BOTH,
+
+    /**
      * 对标 Dist.CLIENT
      * 对标 EnvType.CLIENT
      */

--- a/common/src/main/kotlin/cn/coostack/cooparticlesapi/event/CooEventBus.kt
+++ b/common/src/main/kotlin/cn/coostack/cooparticlesapi/event/CooEventBus.kt
@@ -3,6 +3,8 @@ package cn.coostack.cooparticlesapi.event
 import cn.coostack.cooparticlesapi.CooParticlesConstants
 import cn.coostack.cooparticlesapi.annotations.events.EventHandler
 import cn.coostack.cooparticlesapi.annotations.events.EventListener
+import cn.coostack.cooparticlesapi.enums.DistType
+import cn.coostack.cooparticlesapi.platform.CooParticlesServices
 import cn.coostack.cooparticlesapi.event.api.CooEvent
 import cn.coostack.cooparticlesapi.event.api.EventExecutor
 import cn.coostack.cooparticlesapi.event.api.EventInterruptible
@@ -42,6 +44,10 @@ object CooEventBus {
         CooAPIScanner.getClassesWithAnnotation(EventListener::class.java)
             .forEach {
                 val value = it.getAnnotation(EventListener::class.java)
+                val dist = value?.dist ?: DistType.BOTH
+                if (dist != DistType.BOTH && dist != CooParticlesServices.PLATFORM.getDistType()) {
+                    return@forEach
+                }
                 appendListenerTarget(value?.modId ?: CooParticlesConstants.MOD_ID, it.name)
             }
         val end = System.currentTimeMillis()

--- a/common/src/main/kotlin/cn/coostack/cooparticlesapi/listeners/DisplayRenderListener.kt
+++ b/common/src/main/kotlin/cn/coostack/cooparticlesapi/listeners/DisplayRenderListener.kt
@@ -4,10 +4,11 @@ import cn.coostack.cooparticlesapi.CooParticlesConstants
 import cn.coostack.cooparticlesapi.annotations.events.EventHandler
 import cn.coostack.cooparticlesapi.annotations.events.EventListener
 import cn.coostack.cooparticlesapi.display.DisplayEntityManager
+import cn.coostack.cooparticlesapi.enums.DistType
 import cn.coostack.cooparticlesapi.event.events.entity.player.PlayerDisconnectEvent
 import cn.coostack.cooparticlesapi.event.events.world.client.ClientWorldRenderEvent
 
-@EventListener(CooParticlesConstants.MOD_ID)
+@EventListener(CooParticlesConstants.MOD_ID, dist = DistType.CLIENT)
 object DisplayRenderListener {
     @EventHandler
     fun onRender(event: ClientWorldRenderEvent) {

--- a/common/src/main/kotlin/cn/coostack/cooparticlesapi/listeners/TestBlockBinderHighlightListener.kt
+++ b/common/src/main/kotlin/cn/coostack/cooparticlesapi/listeners/TestBlockBinderHighlightListener.kt
@@ -5,6 +5,7 @@ import cn.coostack.cooparticlesapi.annotations.events.EventHandler
 import cn.coostack.cooparticlesapi.annotations.events.EventListener
 import cn.coostack.cooparticlesapi.blocks.TestControllerBlock
 import cn.coostack.cooparticlesapi.blocks.TestControllerBlockEntity
+import cn.coostack.cooparticlesapi.enums.DistType
 import cn.coostack.cooparticlesapi.event.events.world.client.ClientWorldRenderEvent
 import cn.coostack.cooparticlesapi.items.CooItems
 import cn.coostack.cooparticlesapi.items.TestBlockBinding
@@ -15,7 +16,7 @@ import net.minecraft.client.renderer.RenderType
 import net.minecraft.world.InteractionHand
 import net.minecraft.world.phys.AABB
 
-@EventListener(CooParticlesConstants.MOD_ID)
+@EventListener(CooParticlesConstants.MOD_ID, dist = DistType.CLIENT)
 object TestBlockBinderHighlightListener {
     private const val HIDDEN_SCAN_CHUNK_RADIUS = 6
 

--- a/common/src/main/kotlin/cn/coostack/cooparticlesapi/listeners/TestBlockPlayerPathListener.kt
+++ b/common/src/main/kotlin/cn/coostack/cooparticlesapi/listeners/TestBlockPlayerPathListener.kt
@@ -4,6 +4,7 @@ import cn.coostack.cooparticlesapi.CooParticlesConstants
 import cn.coostack.cooparticlesapi.annotations.events.EventHandler
 import cn.coostack.cooparticlesapi.annotations.events.EventListener
 import cn.coostack.cooparticlesapi.blocks.TestControllerBlockEntity
+import cn.coostack.cooparticlesapi.enums.DistType
 import cn.coostack.cooparticlesapi.event.events.world.client.ClientWorldRenderEvent
 import cn.coostack.cooparticlesapi.items.CooItems
 import cn.coostack.cooparticlesapi.items.TestBlockBindings
@@ -23,7 +24,7 @@ import kotlin.math.sqrt
  * 示例：动态位置显示青色路径，当前采样点显示红色小框。
  * 禁止在客户端渲染回调中修改方块实体或测试配置。
  */
-@EventListener(CooParticlesConstants.MOD_ID)
+@EventListener(CooParticlesConstants.MOD_ID, dist = DistType.CLIENT)
 object TestBlockPlayerPathListener {
     private const val PATH_SAMPLES = 64
 

--- a/common/src/main/kotlin/cn/coostack/cooparticlesapi/listeners/TestControllerPickRenderListener.kt
+++ b/common/src/main/kotlin/cn/coostack/cooparticlesapi/listeners/TestControllerPickRenderListener.kt
@@ -3,10 +3,11 @@ package cn.coostack.cooparticlesapi.listeners
 import cn.coostack.cooparticlesapi.CooParticlesConstants
 import cn.coostack.cooparticlesapi.annotations.events.EventHandler
 import cn.coostack.cooparticlesapi.annotations.events.EventListener
+import cn.coostack.cooparticlesapi.enums.DistType
 import cn.coostack.cooparticlesapi.event.events.world.client.ClientWorldRenderEvent
 import cn.coostack.cooparticlesapi.test.block.client.TestControllerPickClient
 
-@EventListener(CooParticlesConstants.MOD_ID)
+@EventListener(CooParticlesConstants.MOD_ID, dist = DistType.CLIENT)
 object TestControllerPickRenderListener {
     @EventHandler
     fun onRender(event: ClientWorldRenderEvent) {

--- a/common/src/main/kotlin/cn/coostack/cooparticlesapi/platform/CooClientServices.kt
+++ b/common/src/main/kotlin/cn/coostack/cooparticlesapi/platform/CooClientServices.kt
@@ -1,0 +1,19 @@
+package cn.coostack.cooparticlesapi.platform
+
+import cn.coostack.cooparticlesapi.display.CooRenderTypesProvider
+import cn.coostack.cooparticlesapi.utils.api.ModelPartPointCollector
+
+/**
+ * Services whose types are client-only must not be initialized from the common
+ * service registry.  Keep this object on the client call path so dedicated
+ * servers never resolve PoseStack, ModelPart, or RenderType.
+ */
+object CooClientServices {
+    @JvmField
+    val RENDER_TYPES_PROVIDER: CooRenderTypesProvider =
+        CooParticlesServices.load(CooRenderTypesProvider::class.java)
+
+    @JvmField
+    val MODEL_PART_POINT_COLLECTOR: ModelPartPointCollector =
+        CooParticlesServices.load(ModelPartPointCollector::class.java)
+}

--- a/common/src/main/kotlin/cn/coostack/cooparticlesapi/platform/CooParticlesServices.kt
+++ b/common/src/main/kotlin/cn/coostack/cooparticlesapi/platform/CooParticlesServices.kt
@@ -2,7 +2,6 @@ package cn.coostack.cooparticlesapi.platform
 
 import cn.coostack.cooparticlesapi.CooParticlesConstants
 import cn.coostack.cooparticlesapi.platform.services.IPlatformHelper
-import cn.coostack.cooparticlesapi.utils.api.ModelPartPointCollector
 import java.util.*
 import java.util.function.Supplier
 
@@ -24,9 +23,6 @@ object CooParticlesServices {
 
     @JvmField
     val COO_REGISTRY = load(CooRegistry::class.java)
-
-    @JvmField
-    val MODEL_PART_POINT_COLLECTOR: ModelPartPointCollector = load(ModelPartPointCollector::class.java)
 
     // This code is used to load a service for the current environment. Your implementation o   f the service must be defined
     // manually by including a text file in META-INF/services named with the fully qualified class name of the service.

--- a/common/src/main/kotlin/cn/coostack/cooparticlesapi/platform/services/IPlatformHelper.kt
+++ b/common/src/main/kotlin/cn/coostack/cooparticlesapi/platform/services/IPlatformHelper.kt
@@ -1,6 +1,5 @@
 package cn.coostack.cooparticlesapi.platform.services
 
-import cn.coostack.cooparticlesapi.display.CooRenderTypesProvider
 import cn.coostack.cooparticlesapi.enums.DistType
 
 interface IPlatformHelper {
@@ -26,17 +25,8 @@ interface IPlatformHelper {
      */
     fun isDevelopmentEnvironment(): Boolean
     fun getDistType(): DistType
-
-    /**
-     * Gets the name of the environment type as a string.
-     *
-     * @return The name of the environment type.
-     */
+    /** Gets the name of the environment type as a string. */
     fun getEnvironmentName(): String {
         return if (isDevelopmentEnvironment()) "development" else "production"
     }
-
-
-    fun getRenderTypesProvider(): CooRenderTypesProvider
-
 }

--- a/common/src/main/kotlin/cn/coostack/cooparticlesapi/renderer/terrain/CooTerrainPipelineManager.kt
+++ b/common/src/main/kotlin/cn/coostack/cooparticlesapi/renderer/terrain/CooTerrainPipelineManager.kt
@@ -5,6 +5,7 @@ import cn.coostack.cooparticlesapi.CooParticlesConstants
 import cn.coostack.cooparticlesapi.compat.IrisCompat
 import cn.coostack.cooparticlesapi.compat.IrisTerrainDepthTexture
 import cn.coostack.cooparticlesapi.platform.CooParticlesServices
+import cn.coostack.cooparticlesapi.platform.CooClientServices
 import cn.coostack.cooparticlesapi.renderer.backend.RenderSceneResources
 import cn.coostack.cooparticlesapi.renderer.backend.RenderSceneTargets
 import cn.coostack.cooparticlesapi.renderer.backend.RenderFrameContext
@@ -626,7 +627,7 @@ internal object CooTerrainPipelineManager {
             )
             return emptyList()
         }
-        val renderType = CooParticlesServices.PLATFORM.getRenderTypesProvider().terrain(
+        val renderType = CooClientServices.RENDER_TYPES_PROVIDER.terrain(
             pipeline,
             baseLayer,
             batchKey
@@ -1806,7 +1807,7 @@ internal object CooTerrainPipelineManager {
             terrainMappings.clear()
             terrainMappingBatchKeys.clear()
         }
-        CooParticlesServices.PLATFORM.getRenderTypesProvider().clearTerrainCache()
+        CooClientServices.RENDER_TYPES_PROVIDER.clearTerrainCache()
         synchronized(shaders) {
             shaders.values.forEach(ShaderInstance::close)
             shaders.clear()

--- a/common/src/main/kotlin/cn/coostack/cooparticlesapi/test/options/display/TestShapeDisplayEntity.kt
+++ b/common/src/main/kotlin/cn/coostack/cooparticlesapi/test/options/display/TestShapeDisplayEntity.kt
@@ -5,7 +5,7 @@ import cn.coostack.cooparticlesapi.annotations.CooAutoRegister
 import cn.coostack.cooparticlesapi.annotations.CodecField
 import cn.coostack.cooparticlesapi.annotations.display.handle.DisplayEntityRegistryHelper
 import cn.coostack.cooparticlesapi.display.DisplayEntity
-import cn.coostack.cooparticlesapi.platform.CooParticlesServices
+import cn.coostack.cooparticlesapi.platform.CooClientServices
 import com.mojang.blaze3d.systems.RenderSystem
 import com.mojang.blaze3d.vertex.PoseStack
 import com.mojang.blaze3d.vertex.VertexConsumer
@@ -54,7 +54,7 @@ class TestShapeDisplayEntity(pos: Vec3, world: Level?) : DisplayEntity(pos, worl
         camera: Camera
     ) {
         modelMatrixStack.pushPose()
-        val provider = CooParticlesServices.PLATFORM.getRenderTypesProvider()
+        val provider = CooClientServices.RENDER_TYPES_PROVIDER
         val layeredConsumer = provider.layered(LAYERED_GLOW_ID)?.consumer(buffer)
         val consumer = layeredConsumer ?: buffer.getBuffer(provider.glow())
         renderCylinder(

--- a/common/src/main/kotlin/cn/coostack/cooparticlesapi/test/options/particle/composition/TestModelComposition.kt
+++ b/common/src/main/kotlin/cn/coostack/cooparticlesapi/test/options/particle/composition/TestModelComposition.kt
@@ -4,7 +4,7 @@ import cn.coostack.cooparticlesapi.annotations.CooAutoRegister
 import cn.coostack.cooparticlesapi.extend.asRelative
 import cn.coostack.cooparticlesapi.network.particle.composition.AutoParticleComposition
 import cn.coostack.cooparticlesapi.network.particle.composition.CompositionData
-import cn.coostack.cooparticlesapi.platform.CooParticlesServices
+import cn.coostack.cooparticlesapi.platform.CooClientServices
 import cn.coostack.cooparticlesapi.utils.RelativeLocation
 import com.mojang.blaze3d.vertex.PoseStack
 import com.mojang.math.Axis
@@ -17,7 +17,7 @@ import net.minecraft.world.phys.Vec3
 class TestModelComposition(position: Vec3, world: Level? = null) : AutoParticleComposition(position, world) {
     override fun getParticles(): Map<CompositionData, RelativeLocation> {
         val model = Minecraft.getInstance().entityModels.bakeLayer(ModelLayers.WOLF)
-        val points = CooParticlesServices.MODEL_PART_POINT_COLLECTOR
+        val points = CooClientServices.MODEL_PART_POINT_COLLECTOR
             .collectSamplePoints(
                 model, PoseStack()
                     .apply {

--- a/fabric/src/main/kotlin/cn/coostack/cooparticlesapi/platform/FabricPlatformHelper.kt
+++ b/fabric/src/main/kotlin/cn/coostack/cooparticlesapi/platform/FabricPlatformHelper.kt
@@ -1,6 +1,5 @@
 package cn.coostack.cooparticlesapi.platform
 
-import cn.coostack.cooparticlesapi.display.CooRenderTypesProvider
 import cn.coostack.cooparticlesapi.enums.DistType
 import cn.coostack.cooparticlesapi.platform.services.IPlatformHelper
 import net.fabricmc.api.EnvType
@@ -25,9 +24,4 @@ class FabricPlatformHelper : IPlatformHelper {
             EnvType.SERVER -> DistType.SERVER
         }
     }
-
-    override fun getRenderTypesProvider(): CooRenderTypesProvider {
-        return FabricRenderTypesProvider
-    }
-
 }

--- a/fabric/src/main/kotlin/cn/coostack/cooparticlesapi/platform/FabricRenderTypesProviderService.kt
+++ b/fabric/src/main/kotlin/cn/coostack/cooparticlesapi/platform/FabricRenderTypesProviderService.kt
@@ -1,0 +1,6 @@
+package cn.coostack.cooparticlesapi.platform
+
+import cn.coostack.cooparticlesapi.display.CooRenderTypesProvider
+
+/** Public-constructor ServiceLoader adapter for the Kotlin singleton provider. */
+class FabricRenderTypesProviderService : CooRenderTypesProvider by FabricRenderTypesProvider

--- a/fabric/src/main/resources/META-INF/services/cn.coostack.cooparticlesapi.display.CooRenderTypesProvider
+++ b/fabric/src/main/resources/META-INF/services/cn.coostack.cooparticlesapi.display.CooRenderTypesProvider
@@ -1,0 +1,1 @@
+cn.coostack.cooparticlesapi.platform.FabricRenderTypesProviderService

--- a/neoforge/src/main/java/cn/coostack/cooparticlesapi/mixin/SectionCompilerNeoForgeMixin.java
+++ b/neoforge/src/main/java/cn/coostack/cooparticlesapi/mixin/SectionCompilerNeoForgeMixin.java
@@ -1,0 +1,188 @@
+package cn.coostack.cooparticlesapi.mixin;
+
+import cn.coostack.cooparticlesapi.renderer.terrain.CooTerrainPipelineManager;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.MeshData;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.blaze3d.vertex.VertexSorting;
+import net.minecraft.client.renderer.ItemBlockRenderTypes;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.SectionBufferBuilderPack;
+import net.minecraft.client.renderer.block.BlockRenderDispatcher;
+import net.minecraft.client.renderer.chunk.RenderChunkRegion;
+import net.minecraft.client.renderer.chunk.SectionCompiler;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.SectionPos;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.FluidState;
+import net.neoforged.neoforge.client.model.data.ModelData;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.List;
+import java.util.Map;
+
+/** NeoForge's SectionCompiler overload carries ModelData and RenderType. */
+@Mixin(SectionCompiler.class)
+public abstract class SectionCompilerNeoForgeMixin {
+    private static final String COMPILE_METHOD =
+            "compile(Lnet/minecraft/core/SectionPos;" +
+                    "Lnet/minecraft/client/renderer/chunk/RenderChunkRegion;" +
+                    "Lcom/mojang/blaze3d/vertex/VertexSorting;" +
+                    "Lnet/minecraft/client/renderer/SectionBufferBuilderPack;" +
+                    "Ljava/util/List;)" +
+                    "Lnet/minecraft/client/renderer/chunk/SectionCompiler$Results;";
+
+    @WrapOperation(
+            method = COMPILE_METHOD,
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/renderer/block/BlockRenderDispatcher;renderLiquid(" +
+                            "Lnet/minecraft/core/BlockPos;" +
+                            "Lnet/minecraft/world/level/BlockAndTintGetter;" +
+                            "Lcom/mojang/blaze3d/vertex/VertexConsumer;" +
+                            "Lnet/minecraft/world/level/block/state/BlockState;" +
+                            "Lnet/minecraft/world/level/material/FluidState;)V"
+            )
+    )
+    private void cooParticlesAPI$writeTerrainFluidOverlayBatch(
+            BlockRenderDispatcher dispatcher,
+            BlockPos pos,
+            BlockAndTintGetter level,
+            VertexConsumer consumer,
+            BlockState state,
+            FluidState fluidState,
+            Operation<Void> original,
+            @Local Map<RenderType, BufferBuilder> renderedLayers,
+            @Local(argsOnly = true) SectionBufferBuilderPack sectionBufferBuilderPack
+    ) {
+        RenderType baseLayer = ItemBlockRenderTypes.getRenderLayer(fluidState);
+        List<RenderType> overlayLayers = CooTerrainPipelineManager.resolveOverlayRenderTypes(state, baseLayer, pos);
+        if (overlayLayers.isEmpty() || CooTerrainPipelineManager.shouldPreserveVanillaTerrainGeometry(overlayLayers)) {
+            original.call(dispatcher, pos, level, consumer, state, fluidState);
+        }
+        for (RenderType overlayLayer : overlayLayers) {
+            BufferBuilder overlayBuffer = renderedLayers.computeIfAbsent(
+                    overlayLayer,
+                    key -> new BufferBuilder(
+                            sectionBufferBuilderPack.buffer(key),
+                            key.mode(),
+                            CooTerrainPipelineManager.vertexFormat(key, key.format())
+                    )
+            );
+            VertexConsumer overlayConsumer = CooTerrainPipelineManager.decorateVertexConsumer(
+                    overlayLayer,
+                    pos,
+                    overlayBuffer
+            );
+            original.call(dispatcher, pos, level, overlayConsumer, state, fluidState);
+        }
+    }
+
+    @WrapOperation(
+            method = COMPILE_METHOD,
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/renderer/block/BlockRenderDispatcher;renderBatched(" +
+                            "Lnet/minecraft/world/level/block/state/BlockState;" +
+                            "Lnet/minecraft/core/BlockPos;" +
+                            "Lnet/minecraft/world/level/BlockAndTintGetter;" +
+                            "Lcom/mojang/blaze3d/vertex/PoseStack;" +
+                            "Lcom/mojang/blaze3d/vertex/VertexConsumer;" +
+                            "Z" +
+                            "Lnet/minecraft/util/RandomSource;" +
+                            "Lnet/neoforged/neoforge/client/model/data/ModelData;" +
+                            "Lnet/minecraft/client/renderer/RenderType;)V"
+            )
+    )
+    private void cooParticlesAPI$writeTerrainOverlayBatch(
+            BlockRenderDispatcher dispatcher,
+            BlockState state,
+            BlockPos pos,
+            BlockAndTintGetter level,
+            PoseStack poseStack,
+            VertexConsumer consumer,
+            boolean checkSides,
+            RandomSource random,
+            ModelData modelData,
+            RenderType renderType,
+            Operation<Void> original,
+            @Local Map<RenderType, BufferBuilder> renderedLayers,
+            @Local(argsOnly = true) SectionBufferBuilderPack sectionBufferBuilderPack
+    ) {
+        RenderType baseLayer = ItemBlockRenderTypes.getChunkRenderType(state);
+        List<RenderType> overlayLayers = CooTerrainPipelineManager.resolveOverlayRenderTypes(state, baseLayer, pos);
+        if (overlayLayers.isEmpty() || CooTerrainPipelineManager.shouldPreserveVanillaTerrainGeometry(overlayLayers)) {
+            poseStack.pushPose();
+            try {
+                original.call(
+                        dispatcher, state, pos, level, poseStack, consumer, checkSides, random, modelData, renderType
+                );
+            } finally {
+                poseStack.popPose();
+            }
+        }
+        for (RenderType overlayLayer : overlayLayers) {
+            BufferBuilder overlayBuffer = renderedLayers.computeIfAbsent(
+                    overlayLayer,
+                    key -> new BufferBuilder(
+                            sectionBufferBuilderPack.buffer(key),
+                            key.mode(),
+                            CooTerrainPipelineManager.vertexFormat(key, key.format())
+                    )
+            );
+            VertexConsumer overlayConsumer = CooTerrainPipelineManager.decorateVertexConsumer(
+                    overlayLayer,
+                    pos,
+                    overlayBuffer
+            );
+            random.setSeed(state.getSeed(pos));
+            poseStack.pushPose();
+            try {
+                original.call(
+                        dispatcher,
+                        state,
+                        pos,
+                        level,
+                        poseStack,
+                        overlayConsumer,
+                        checkSides,
+                        random,
+                        modelData,
+                        overlayLayer
+                );
+            } finally {
+                poseStack.popPose();
+            }
+        }
+    }
+
+    @WrapOperation(
+            method = COMPILE_METHOD,
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+            )
+    )
+    private Object cooParticlesAPI$sortTranslucentTerrainPipeline(
+            Map<RenderType, MeshData> renderedLayers,
+            Object renderTypeObject,
+            Object meshDataObject,
+            Operation<Object> original,
+            @Local(argsOnly = true) VertexSorting vertexSorting,
+            @Local(argsOnly = true) SectionBufferBuilderPack sectionBufferBuilderPack
+    ) {
+        RenderType renderType = (RenderType) renderTypeObject;
+        MeshData meshData = (MeshData) meshDataObject;
+        if (CooTerrainPipelineManager.requiresTerrainSorting(renderType)) {
+            meshData.sortQuads(sectionBufferBuilderPack.buffer(renderType), vertexSorting);
+        }
+        return original.call(renderedLayers, renderType, meshData);
+    }
+}

--- a/neoforge/src/main/kotlin/cn/coostack/cooparticlesapi/platform/NeoForgePlatformHelper.kt
+++ b/neoforge/src/main/kotlin/cn/coostack/cooparticlesapi/platform/NeoForgePlatformHelper.kt
@@ -1,6 +1,5 @@
 package cn.coostack.cooparticlesapi.platform
 
-import cn.coostack.cooparticlesapi.display.CooRenderTypesProvider
 import cn.coostack.cooparticlesapi.enums.DistType
 import cn.coostack.cooparticlesapi.platform.services.IPlatformHelper
 import net.neoforged.api.distmarker.Dist
@@ -25,9 +24,5 @@ class NeoForgePlatformHelper : IPlatformHelper {
             Dist.CLIENT -> DistType.CLIENT
             Dist.DEDICATED_SERVER -> DistType.SERVER
         }
-    }
-
-    override fun getRenderTypesProvider(): CooRenderTypesProvider {
-        return NeoRenderTypesProvider
     }
 }

--- a/neoforge/src/main/kotlin/cn/coostack/cooparticlesapi/platform/NeoRenderTypesProviderService.kt
+++ b/neoforge/src/main/kotlin/cn/coostack/cooparticlesapi/platform/NeoRenderTypesProviderService.kt
@@ -1,0 +1,6 @@
+package cn.coostack.cooparticlesapi.platform
+
+import cn.coostack.cooparticlesapi.display.CooRenderTypesProvider
+
+/** Public-constructor ServiceLoader adapter for the Kotlin singleton provider. */
+class NeoRenderTypesProviderService : CooRenderTypesProvider by NeoRenderTypesProvider

--- a/neoforge/src/main/resources/META-INF/services/cn.coostack.cooparticlesapi.display.CooRenderTypesProvider
+++ b/neoforge/src/main/resources/META-INF/services/cn.coostack.cooparticlesapi.display.CooRenderTypesProvider
@@ -1,0 +1,1 @@
+cn.coostack.cooparticlesapi.platform.NeoRenderTypesProviderService


### PR DESCRIPTION
## 变更说明

修复 Issue #12：CooParticlesAPI 在专用服务端初始化过程中加载客户端类 `PoseStack`，导致服务端启动失败。

## 修复内容

- 将 `CooRenderTypesProvider`、`ModelPartPointCollector` 等客户端类型从通用服务注册表移到客户端服务路径。
- 为事件监听器增加运行端标记，服务端跳过客户端渲染监听器，避免反射加载客户端类。
- 补充 NeoForge 地形 SectionCompiler mixin 及 RenderTypesProvider 的 ServiceLoader 适配。

## 验证结果

- `./gradlew :neoforge:build` 构建成功。
- `./gradlew :neoforge:runServer` 启动成功并进入 `Done ...! For help, type help`。
- 服务端启动过程中未再出现 `PoseStack` 或其他客户端类加载错误。

关联 #12。